### PR TITLE
Bugfix 50% hanging

### DIFF
--- a/Mod/Data/Scripts/AsteroidOres/Client.cs
+++ b/Mod/Data/Scripts/AsteroidOres/Client.cs
@@ -17,6 +17,7 @@ namespace StalkR.AsteroidOres
             this.active = new HashSet<long>();
             this.pending = new HashSet<long>();
             this.pendingEntities = new Dictionary<long, IMyEntity>();
+	    this.spawned = false;
 
             Mod.Log($"AsteroidOres: Client up");
         }

--- a/Mod/Data/Scripts/AsteroidOres/Client.cs
+++ b/Mod/Data/Scripts/AsteroidOres/Client.cs
@@ -8,27 +8,36 @@ namespace StalkR.AsteroidOres
 {
     public class Client : ISide
     {
-        private HashSet<long> active = new HashSet<long>();
-        private HashSet<long> pending = new HashSet<long>();
-        private Dictionary<long, IMyEntity> pendingEntities = new Dictionary<long, IMyEntity>();
+        private HashSet<long> active;
+        private HashSet<long> pending;
+        private Dictionary<long, IMyEntity> pendingEntities;
+        private bool spawned;
+
+        public Client() {
+            this.active = new HashSet<long>();
+            this.pending = new HashSet<long>();
+            this.pendingEntities = new Dictionary<long, IMyEntity>();
+
+            Mod.Log($"AsteroidOres: Client up");
+        }
 
         public void UnloadData()
         {
-            active.Clear();
-            pending.Clear();
-            pendingEntities.Clear();
+            this.active.Clear();
+            this.pending.Clear();
+            this.pendingEntities.Clear();
         }
 
         public void OnEntityAdd(IMyEntity entity)
         {
             if (!(entity is MyVoxelBase)) return;
             if (!Mod.isAsteroid(entity as MyVoxelBase)) return;
-            var p = entity.GetPosition();
-            Mod.Log($"AsteroidOres: add X:{p.X} Y:{p.Y} Z:{p.Z}");
-            if (!active.Contains(entity.EntityId))
+            //var p = entity.GetPosition(); // ToDo: no need for p if debug is off
+            //Mod.Log($"AsteroidOres: add X:{p.X} Y:{p.Y} Z:{p.Z}");
+            if (!this.active.Contains(entity.EntityId))
             {
-                pending.Add(entity.EntityId);
-                pendingEntities.Add(entity.EntityId, entity);
+                this.pending.Add(entity.EntityId);
+                this.pendingEntities.Add(entity.EntityId, entity);
                 entity.Render.UpdateRenderObject(false);
                 entity.Physics.Deactivate();
             }
@@ -38,51 +47,63 @@ namespace StalkR.AsteroidOres
         {
             if (!(entity is MyVoxelBase)) return;
             if (!Mod.isAsteroid(entity as MyVoxelBase)) return;
-            var p = entity.GetPosition();
-            Mod.Log($"AsteroidOres: remove X:{p.X} Y:{p.Y} Z:{p.Z}");
-            active.Remove(entity.EntityId);
-            pending.Remove(entity.EntityId);
-            pendingEntities.Remove(entity.EntityId);
+            //var p = entity.GetPosition();
+            //Mod.Log($"AsteroidOres: remove X:{p.X} Y:{p.Y} Z:{p.Z}");
+            this.active.Remove(entity.EntityId);
+            this.pending.Remove(entity.EntityId);
+            this.pendingEntities.Remove(entity.EntityId);
         }
 
         public void UpdateBeforeSimulation100()
         {
-            if (pending.Count == 0) return;
-            Mod.Log($"AsteroidOres: ask server for {pending.Count} pending");
+            if (this.pending.Count == 0) return;
+            Mod.Log($"AsteroidOres: ask server for {this.pending.Count} pending");
             Mod.SendMessageToServer(MyAPIGateway.Utilities.SerializeToBinary(new Message { pending = pending }));
         }
 
         public void OnMessage(ushort handlerId, byte[] serialized, ulong senderPlayerId, bool isArrivedFromServer)
         {
-            if (!isArrivedFromServer) return;
+			if (!isArrivedFromServer) return;
+			Mod.Log($"AsteroidOres: Msg from server");
+			if (!spawned)
+			{
+				IMyCharacter character = MyAPIGateway.Session?.Player?.Character;
+				if (character != null) { // wait until first spawn 
+					spawned = true;                
+					Mod.Log($"AsteroidOres: Ready Player One");
+				}
+                // Do not optimize, drop first msg for more delay
+				return;
+			}
+			
             var msg = MyAPIGateway.Utilities.SerializeFromBinary<Server.Message>(serialized);
             if (msg.active != null && msg.active.Count > 0)
             {
                 Mod.Log($"AsteroidOres: server sent ({msg.active.Count}) active");
-                foreach (var entityId in msg.active)
+                foreach (var entityId in msg.active)  // Parallel.ForEach ??
                 {
-                    if (!pendingEntities.ContainsKey(entityId)) continue;
+                    if (!this.pendingEntities.ContainsKey(entityId)) continue;
                     var entity = pendingEntities[entityId];
-                    var p = entity.GetPosition();
-                    Mod.Log($"AsteroidOres: activate X:{p.X} Y:{p.Y} Z:{p.Z}");
+                    //var p = entity.GetPosition();
+                    //Mod.Log($"AsteroidOres: activate X:{p.X} Y:{p.Y} Z:{p.Z}");
                     entity.Render.UpdateRenderObject(true);
                     entity.Physics.Activate();
-                    pending.Remove(entityId);
-                    pendingEntities.Remove(entityId);
-                    active.Add(entity.EntityId);
+                    this.pending.Remove(entityId);
+                    this.pendingEntities.Remove(entityId);
+                    this.active.Add(entity.EntityId);
                 }
             }
             if (msg.removed != null && msg.removed.Count > 0)
             {
                 Mod.Log($"AsteroidOres: server sent ({msg.removed.Count}) removed");
-                foreach (var entityId in msg.removed)
+                foreach (var entityId in msg.removed)  // Parallel.ForEach ??
                 {
-                    if (!pendingEntities.ContainsKey(entityId)) continue;
+                    if (!this.pendingEntities.ContainsKey(entityId)) continue;
                     var entity = pendingEntities[entityId];
-                    var p = entity.GetPosition();
-                    Mod.Log($"AsteroidOres: remove X:{p.X} Y:{p.Y} Z:{p.Z}");
-                    pending.Remove(entityId);
-                    pendingEntities.Remove(entityId);
+                    //var p = entity.GetPosition();
+                    //Mod.Log($"AsteroidOres: remove X:{p.X} Y:{p.Y} Z:{p.Z}");
+                    this.pending.Remove(entityId);
+                    this.pendingEntities.Remove(entityId);
                     entity.Delete();
                 }
             }


### PR DESCRIPTION
If character is not spawned do not process any server msgs.
Now with correct constructor.... works too, bool is false anyway...

This should solve the 50% boot hang.

Why is 50% hanging?
If the client receives a server message when booting up and the character doesn't exist, it won't be able to remove anything.
This only happens in places where asteroids COULD form.
So players on planets are not affected because when a message occurs there is nothing to delete (empty msg)

