### PR TITLE
Another 50% bugfix 

### DIFF
--- a/Mod/Data/Scripts/AsteroidOres/Client.cs
+++ b/Mod/Data/Scripts/AsteroidOres/Client.cs
@@ -2,20 +2,27 @@ using ProtoBuf;
 using Sandbox.Game.Entities;
 using Sandbox.ModAPI;
 using System.Collections.Generic;
+using System.Linq;
+using VRage.Collections;
 using VRage.ModAPI;
 
 namespace StalkR.AsteroidOres
 {
     public class Client : ISide
     {
-        private HashSet<long> active = new HashSet<long>();
-        private HashSet<long> pending = new HashSet<long>();
-        private Dictionary<long, IMyEntity> pendingEntities = new Dictionary<long, IMyEntity>();
+        // As far as I tested, now it works....
+        // I also saw some negative <long> values (game debuggin via dnSpy) while logging,
+        // so I set correct types instead of var where needed
+        // Game loads entities in parallel, so hashset needs to be threadsafe  
+        private MyConcurrentHashSet<long> active = new MyConcurrentHashSet<long>();
+        private MyConcurrentDictionary<long, IMyEntity> pendingEntities = new MyConcurrentDictionary<long, IMyEntity>();
+        
+        // false = game is loading || true = game fully loaded (character present etc.)
+        private bool game = false;
 
         public void UnloadData()
         {
             active.Clear();
-            pending.Clear();
             pendingEntities.Clear();
         }
 
@@ -23,14 +30,31 @@ namespace StalkR.AsteroidOres
         {
             if (!(entity is MyVoxelBase)) return;
             if (!Mod.isAsteroid(entity as MyVoxelBase)) return;
-            var p = entity.GetPosition();
-            Mod.Log($"AsteroidOres: add X:{p.X} Y:{p.Y} Z:{p.Z}");
             if (!active.Contains(entity.EntityId))
             {
-                pending.Add(entity.EntityId);
                 pendingEntities.Add(entity.EntityId, entity);
-                entity.Render.UpdateRenderObject(false);
-                entity.Physics.Deactivate();
+                var p = entity.GetPosition();
+                Mod.Log($"AsteroidOres: remove X:{p.X} Y:{p.Y} Z:{p.Z}");
+                Mod.Log($"AsteroidOres: loading finished? {game} ");
+                // DO NOT perform render changes to entities on load
+                // otherwise entity could be removed by the client but the server does not get it
+                // So the server waits for this removed entity to get loaded -> 50% hang 
+                // This happens when other grids loads ore are still present at server
+                // So error did not happen when the grid around the player needs to be loaded
+                // Thats why that after a server restart players are able to connect without error
+                // remember game loads stuff in parallel here
+                // We need to perform render changes when game is running so there are no "plopping" 
+                // roids like in the past version
+
+                // QUESTION:
+                // Is there a chance that a player joins - spawns roid within space at another
+                // player and this player ram it? Gap time is loading time till reoid removed...
+                // 
+                if (game)
+                {
+                    entity.Render.UpdateRenderObject(false);
+                    entity.Physics.Deactivate();
+                }
             }
         }
 
@@ -41,38 +65,36 @@ namespace StalkR.AsteroidOres
             var p = entity.GetPosition();
             Mod.Log($"AsteroidOres: remove X:{p.X} Y:{p.Y} Z:{p.Z}");
             active.Remove(entity.EntityId);
-            pending.Remove(entity.EntityId);
             pendingEntities.Remove(entity.EntityId);
         }
 
         public void UpdateBeforeSimulation100()
         {
-            if (pending.Count == 0) return;
-            // Wait for session/player/character to finish loading before asking server (#11).
-            if (MyAPIGateway.Session?.Player?.Character == null) return;
-            Mod.Log($"AsteroidOres: ask server for {pending.Count} pending");
-            Mod.SendMessageToServer(MyAPIGateway.Utilities.SerializeToBinary(new Message { pending = pending }));
+            if (pendingEntities.Count == 0) return;
+            // Not needed anymore, had no effect at all. False positive.
+            //if (MyAPIGateway.Session?.Player?.Character == null) return;
+            Mod.Log($"AsteroidOres: ask server for {pendingEntities.Count} pending");
+            Mod.SendMessageToServer(MyAPIGateway.Utilities.SerializeToBinary(
+                new Message { pending = pendingEntities.Keys.ToHashSet<long>() }
+                ));
         }
 
         public void OnMessage(ushort handlerId, byte[] serialized, ulong senderPlayerId, bool isArrivedFromServer)
         {
             if (!isArrivedFromServer) return;
-            // It seems we cannot remove asteroids without a character (#11).
-            if (MyAPIGateway.Session?.Player?.Character == null) return;
-            var msg = MyAPIGateway.Utilities.SerializeFromBinary<Server.Message>(serialized);
+            // Not needed anymore, had no effect at all. False positive.
+            //if (MyAPIGateway.Session?.Player?.Character == null) return;
+            var msg = MyAPIGateway.Utilities.SerializeFromBinary<Server.Message>(serialized);            
+            IMyEntity entity;
+
             if (msg.active != null && msg.active.Count > 0)
             {
                 Mod.Log($"AsteroidOres: server sent ({msg.active.Count}) active");
                 foreach (var entityId in msg.active)
                 {
-                    if (!pendingEntities.ContainsKey(entityId)) continue;
-                    var entity = pendingEntities[entityId];
-                    var p = entity.GetPosition();
-                    Mod.Log($"AsteroidOres: activate X:{p.X} Y:{p.Y} Z:{p.Z}");
+                    if (!pendingEntities.TryRemove(entityId, out entity)) continue;
                     entity.Render.UpdateRenderObject(true);
                     entity.Physics.Activate();
-                    pending.Remove(entityId);
-                    pendingEntities.Remove(entityId);
                     active.Add(entity.EntityId);
                 }
             }
@@ -81,15 +103,18 @@ namespace StalkR.AsteroidOres
                 Mod.Log($"AsteroidOres: server sent ({msg.removed.Count}) removed");
                 foreach (var entityId in msg.removed)
                 {
-                    if (!pendingEntities.ContainsKey(entityId)) continue;
-                    var entity = pendingEntities[entityId];
-                    var p = entity.GetPosition();
-                    Mod.Log($"AsteroidOres: remove X:{p.X} Y:{p.Y} Z:{p.Z}");
-                    pending.Remove(entityId);
-                    pendingEntities.Remove(entityId);
+                    if (!pendingEntities.TryRemove(entityId, out entity)) continue;
+                    // QUESTION: Why delete() instead of close() ?
                     entity.Delete();
+                    // no need to put other stuff here becuase OnEntityRemove is called anyway
                 }
             }
+            // Now the game should be running.
+            // We need a way to monitor when loading is completed
+            // Because a lot is in parallel, 50% hang could occur if there are very very huge grids to load...
+            // I need to add a gui / hud check, then player would see poping roids one time but thats it...
+            // Tested and working with about 500k PCU on load
+            game = true;
         }
 
         [ProtoContract]

--- a/Mod/Data/Scripts/AsteroidOres/Mod.cs
+++ b/Mod/Data/Scripts/AsteroidOres/Mod.cs
@@ -1,4 +1,5 @@
 using Sandbox.Game.Entities;
+using Sandbox.Game.World;
 using Sandbox.ModAPI;
 using System.Collections.Generic;
 using VRage.Game;
@@ -56,9 +57,11 @@ namespace StalkR.AsteroidOres
                 return false;
             });
             MyAPIGateway.Entities.OnEntityAdd += side.OnEntityAdd;
-            MyAPIGateway.Entities.OnEntityRemove += side.OnEntityRemove;
+            MyAPIGateway.Entities.OnEntityRemove += side.OnEntityRemove;            
             MyLog.Default.WriteLineAndConsole($"AsteroidOres: BeforeStart: mod started");
         }
+
+        
 
         private int ticks = 0;
         public override void UpdateBeforeSimulation()

--- a/Mod/Data/Scripts/AsteroidOres/Server.cs
+++ b/Mod/Data/Scripts/AsteroidOres/Server.cs
@@ -45,10 +45,13 @@ namespace StalkR.AsteroidOres
                 active = new HashSet<long>(),
                 removed = new HashSet<long>(),
             };
+
             foreach (var entityId in request.pending)
             {
-                if (tracked.Contains(entityId)) response.active.Add(entityId);
-                else response.removed.Add(entityId);
+                if (tracked.Contains(entityId))
+                    response.active.Add(entityId);
+                else
+                    response.removed.Add(entityId);
             }
             Mod.Log($"AsteroidOres: {senderPlayerId} asked {request.pending.Count} pending, responded {response.active.Count} active and {response.removed.Count} removed");
             Mod.SendMessageTo(MyAPIGateway.Utilities.SerializeToBinary(response), senderPlayerId);


### PR DESCRIPTION
Sad to say but in the end it seems that is was the mod. 
But this bug is really hard to get because the game loading some in parallel.

This would be my first draft in order to solve it. 
I will roll it out at my server and test. Time will tell....
At least another try to fight the 50% bug.

Maybe you find some time to answer the questions commented in code.

QUESTION:
Is there a chance that a player joins - spawns roid within space at another
player and this player ram it? Gap time is loading time till reoid removed...

QUESTION: 
Why delete() instead of close() ?


Monitor:
Line 117        game = true;
Is this in time or do we find another trigger to let the client know that all is loaded?

